### PR TITLE
(WIP) Windows update

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -436,11 +436,6 @@ func MigrateToDnoteDir(ctx infra.DnoteCtx) error {
 		return errors.Wrap(err, "Failed to make temporary .dnote directory")
 	}
 
-	// In the beta release for v0.2, backup user's .dnote
-	if err := utils.CopyFile(oldDnotePath, fmt.Sprintf("%s/dnote-bak-5cdde2e83", homeDir)); err != nil {
-		return errors.Wrap(err, "Failed to back up the old .dnote file")
-	}
-
 	if err := os.Rename(oldDnotePath, fmt.Sprintf("%s/dnote", temporaryDirPath)); err != nil {
 		return errors.Wrap(err, "Failed to move .dnote file")
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// Version is the current version of dnote
-	Version = "0.2.1"
+	Version = "0.2.2"
 
 	// TimestampFilename is the name of the file containing upgrade info
 	TimestampFilename = "timestamps"

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -36,6 +36,23 @@ func getAssetName() string {
 	}
 
 	return ret
+}
+
+// getBinaryPath returns the path to the currently executing Dnote binary
+func getBinaryPath() (string, error) {
+	var ret string
+
+	ex, err := os.Executable()
+	if err != nil {
+		return ret, errors.Wrap(err, "Failed to look up the pathname for current process")
+	}
+
+	ret, err = filepath.EvalSymlinks(ex)
+	if err != nil {
+		return ret, errors.Wrap(err, "Failed to follow any synlinks")
+	}
+
+	return ret, nil
 }
 
 // getAsset finds the asset to download from the liast of assets in a release
@@ -166,7 +183,7 @@ func Upgrade(ctx infra.DnoteCtx) error {
 	}
 
 	// Override the binary
-	cmdPath, err := exec.LookPath("dnote")
+	cmdPath, err := getBinaryPath()
 	if err != nil {
 		return errors.Wrap(err, "Failed to look up the binary path")
 	}


### PR DESCRIPTION
```
C:\Users\a\Downloads> .\dnote-windows-amd64.exe upgrade
  • current version is 0.2.2
  • latest version is 0.2.1
  • downloading: 0.2.1
  ⨯ Failed to upgrade dnote: Failed to copy binary from temporary path: rename C:\Users\a\AppData\Local\Temp/dnote_updat
e C:\Users\a\Downloads\dnote-windows-amd64.exe: The process cannot access the file because it is being used by another p
rocess.
```

