### PR TITLE
Fix editor finder command

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -93,8 +93,10 @@ func getEditorCommand() string {
 		return "nano"
 	case "emacs":
 		return "emacs"
-	default:
+	case "":
 		return "vi"
+	default:
+		return editor
 	}
 }
 


### PR DESCRIPTION
os.Getenv will return an empty string if a value is unset. This PR defaults an empty value to vi, and allows to use an actual EDITOR value for those editors you don't support directly.