### PR TITLE
Fix note_uuid in action when removing note

### DIFF
--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -94,9 +94,9 @@ func note(ctx infra.DnoteCtx, index int, bookName string) error {
 		return nil
 	}
 
+	note := notes[index]
 	dnote[bookName] = core.GetUpdatedBook(dnote[bookName], append(notes[:index], notes[index+1:]...))
 
-	note := notes[index]
 	err = core.LogActionRemoveNote(ctx, note.UUID, book.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to log action")

--- a/main_test.go
+++ b/main_test.go
@@ -243,7 +243,7 @@ func TestRemoveNote(t *testing.T) {
 	testutils.WriteFile(ctx, "./testutils/fixtures/dnote3.json", "dnote")
 
 	// Execute
-	cmd, stderr, err := newDnoteCmd(ctx, "remove", "js", "1")
+	cmd, stderr, err := newDnoteCmd(ctx, "remove", "js", "0")
 	if err != nil {
 		panic(errors.Wrap(err, "Failed to get command"))
 	}
@@ -296,13 +296,13 @@ func TestRemoveNote(t *testing.T) {
 
 	testutils.AssertEqual(t, len(actionSlice), 1, "There should be 1 action")
 	testutils.AssertEqual(t, action.Type, actions.ActionRemoveNote, "action type mismatch")
-	testutils.AssertEqual(t, actionData.NoteUUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "action data note_uuid mismatch")
+	testutils.AssertEqual(t, actionData.NoteUUID, "43827b9a-c2b0-4c06-a290-97991c896653", "action data note_uuid mismatch")
 	testutils.AssertEqual(t, actionData.BookName, "js", "action data book_name mismatch")
 	testutils.AssertNotEqual(t, action.Timestamp, 0, "action timestamp mismatch")
 	testutils.AssertEqual(t, len(book.Notes), 1, "Book should have one note")
 	testutils.AssertEqual(t, len(otherBook.Notes), 1, "Other book should have one note")
-	testutils.AssertEqual(t, book.Notes[0].UUID, "43827b9a-c2b0-4c06-a290-97991c896653", "Note should have UUID")
-	testutils.AssertEqual(t, book.Notes[0].Content, "Booleans have toString()", "Note content mismatch")
+	testutils.AssertEqual(t, book.Notes[0].UUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "Note should have UUID")
+	testutils.AssertEqual(t, book.Notes[0].Content, "Date object implements mathematical comparisons", "Note content mismatch")
 }
 
 func TestRemoveBook(t *testing.T) {


### PR DESCRIPTION
* action for removing a note was referencing a note following the one that got deleted.
* if you ever deleted a note and synced, your local data and cloud data are not consistent with one another. To resolve, please sync, delete your local `.dnote` directory, and sync again to download a fresh data. Concretely, you will have lost some notes you did not delete and instead retained notes you did delete.