### PR TITLE
Keep cli output consitent by using same output format in add and edit commands

### DIFF
--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -2,6 +2,7 @@ package edit
 
 import (
 	"database/sql"
+	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -106,8 +107,10 @@ func newRun(ctx infra.DnoteCtx) core.RunEFunc {
 
 		tx.Commit()
 
-		log.Printf("new content: %s\n", newContent)
 		log.Success("edited the note\n")
+		fmt.Printf("\n------------------------content------------------------\n")
+		fmt.Printf("%s", newContent)
+		fmt.Printf("\n-------------------------------------------------------\n")
 
 		return nil
 	}


### PR DESCRIPTION
Related to #121 

![screen shot 2018-10-04 at 17 30 59](https://user-images.githubusercontent.com/245691/46488920-fc650e00-c7fb-11e8-89af-a9f999be2ca9.png)
