### PR TITLE
Change license to GPLv3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,5 @@
-The MIT License (MIT)
+Copyright (c) Monomax Software
 
-Copyright (c) 2016-present Sung Won Cho
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Dnote is an Open Source project licensed under the terms of
+the GPLv3 license. Please see <http://www.gnu.org/licenses/gpl-3.0.html>
+for license text.

--- a/README.md
+++ b/README.md
@@ -35,15 +35,12 @@ Write technical notes without getting distracted from programming. The reasons a
 
 ## Commands
 
-Please refer to ![commands](/COMMANDS.md).
+Please refer to [commands](/COMMANDS.md).
 
 ## Links
 
-* [Website](https://dnote.io)
-* [Making Dnote (blog article)](https://github.com/dnote-io/cli)
-
-## License
-
-MIT
+- [Dnote](https://dnote.io)
+- [Dnote Cloud](https://dnote.io/pricing)
+- [Browser Extension](https://github.com/dnote/browser-extension)
 
 [![Build Status](https://travis-ci.org/dnote/cli.svg?branch=master)](https://travis-ci.org/dnote/cli)


### PR DESCRIPTION
All releases after v0.5.0 will be under GPLv3. All prior versions will remain under MIT.

Please see #146 